### PR TITLE
change: separate dist command for static deploys

### DIFF
--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -246,6 +246,14 @@ gulp.task('copy', (callback) => {
   fs.rename('build', 'dist', callback);
 });
 
+gulp.task('copy:dist', () => {
+  // Explicitly do not use gulp here. It's too slow and messes up the symlinks
+  return gulp.src('build/**/*', {
+    base: 'build'
+  })
+    .pipe(gulp.dest('dist'))
+});
+
 // minify:css minifies the css
 gulp.task('minify:css', () => {
   const srcs = [
@@ -293,7 +301,7 @@ gulp.task('minify', gulp.parallel(
 // appropriate.
 gulp.task('dist', gulp.series(
   'build',
-  'copy',
+  'copy:dist',
   'minify',
 ));
 

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -3414,7 +3414,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3435,12 +3436,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3455,17 +3458,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3582,7 +3588,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3594,6 +3601,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3608,6 +3616,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3615,12 +3624,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3639,6 +3650,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -3700,7 +3712,8 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -3728,7 +3741,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3740,6 +3754,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3817,7 +3832,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3853,6 +3869,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3872,6 +3889,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3915,12 +3933,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
I thought the easiest way without changing much is to create its own copy target that does not *rename*, but actually *copies* files only for dist calls (meaning that this would only affect Netlify builds). 

First tests look good, would be curious what happens if that runs on Netlify.